### PR TITLE
Closes #39 Fix incorrect fallback behavior when backend is unavailable

### DIFF
--- a/__future7/DateToDay.test.js
+++ b/__future7/DateToDay.test.js
@@ -1,0 +1,28 @@
+import { DateToDay } from '../DateToDay'
+
+describe('DateToDay', () => {
+  it.each([
+    ['18/02/2001', 'Sunday'],
+    ['18/12/2020', 'Friday'],
+    ['12/12/2012', 'Wednesday'],
+    ['01/01/2001', 'Monday'],
+    ['1/1/2020', 'Wednesday'],
+    ['2/3/2014', 'Sunday'],
+    ['28/2/2017', 'Tuesday'],
+    ['02/03/2024', 'Saturday'],
+    ['29/02/2024', 'Thursday']
+  ])('%s is %s', (date, day) => {
+    expect(DateToDay(date)).toBe(day)
+  })
+
+  it('should throw when input is not a string', () => {
+    expect(() => DateToDay(100)).toThrowError()
+  })
+
+  it.each(['32/01/2000', '00/01/2000', '15/00/2000', '15/13/2000'])(
+    'should throw when input is not a correct date %s',
+    (wrongDate) => {
+      expect(() => DateToDay(wrongDate)).toThrowError()
+    }
+  )
+})

--- a/__future7/LongestValidParentheses.test.js
+++ b/__future7/LongestValidParentheses.test.js
@@ -1,0 +1,19 @@
+import { longestValidParentheses } from '../LongestValidParentheses'
+
+describe('longestValidParentheses', () => {
+  it('expects to return 0 as longest valid parentheses substring', () => {
+    expect(longestValidParentheses('')).toBe(0)
+  })
+
+  it('expects to return 2 as longest valid parentheses substring', () => {
+    expect(longestValidParentheses('(()')).toBe(2)
+  })
+
+  it('expects to return 2 as longest valid parentheses substring', () => {
+    expect(longestValidParentheses(')()())')).toBe(4)
+  })
+
+  it('expects to return 2 as longest valid parentheses substring', () => {
+    expect(longestValidParentheses('(((')).toBe(0)
+  })
+})

--- a/__future7/palindrome_of_number.cpp
+++ b/__future7/palindrome_of_number.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * @brief Check if a number is
+ * [palindrome](https://en.wikipedia.org/wiki/Palindrome) or not.
+ *
+ * This program cheats by using the STL library's std::reverse function.
+ */
+#include <algorithm>
+#include <iostream>
+
+#ifdef _MSC_VER
+// Required to compile std::toString function using MSVC
+#include <string>
+#else
+#include <cstring>
+#endif
+
+/** Main function */
+int main() {
+    int num;
+    std::cout << "Enter number = ";
+    std::cin >> num;
+
+    std::string s1 = std::to_string(num);  // convert number to string
+    std::string s2 = s1;
+
+    std::reverse(s1.begin(), s1.end());  // reverse the string
+
+    if (s1 == s2)  // check if reverse and original string are identical
+        std::cout << "true";
+    else
+        std::cout << "false";
+
+    return 0;
+}

--- a/__future7/rlecoding_test.go
+++ b/__future7/rlecoding_test.go
@@ -1,0 +1,161 @@
+package compression_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheAlgorithms/Go/compression"
+)
+
+func TestCompressionRLEncode(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "test 1",
+			data: "WWWWWWWWWWWWBWWWWWWWWWWWWBBB",
+			want: "12W1B12W3B",
+		},
+		{
+			name: "test 2",
+			data: "AABCCCDEEEE",
+			want: "2A1B3C1D4E",
+		},
+		{
+			name: "test 3",
+			data: "AAAABBBCCDA",
+			want: "4A3B2C1D1A",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compression.RLEncode(tt.data); got != tt.want {
+				t.Errorf("RLEncode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompressionRLEDecode(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "test 1",
+			data: "12W1B12W3B",
+			want: "WWWWWWWWWWWWBWWWWWWWWWWWWBBB",
+		},
+		{
+			name: "test 2",
+			data: "2A1B3C1D4E",
+			want: "AABCCCDEEEE",
+		},
+		{
+			name: "test 3",
+			data: "4A3B2C1D1A",
+			want: "AAAABBBCCDA",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compression.RLEdecode(tt.data); got != tt.want {
+				t.Errorf("RLEdecode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompressionRLEncodeBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want []byte
+	}{
+		{
+			name: "test 1",
+			data: []byte("WWWWWWWWWWWWBWWWWWWWWWWWWBBB"),
+			want: []byte{12, 'W', 1, 'B', 12, 'W', 3, 'B'},
+		},
+		{
+			name: "test 2",
+			data: []byte("AABCCCDEEEE"),
+			want: []byte{2, 'A', 1, 'B', 3, 'C', 1, 'D', 4, 'E'},
+		},
+		{
+			name: "test 3",
+			data: []byte("AAAABBBCCDA"),
+			want: []byte{4, 'A', 3, 'B', 2, 'C', 1, 'D', 1, 'A'},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compression.RLEncodebytes(tt.data); !bytes.Equal(got, tt.want) {
+				t.Errorf("RLEncodebytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompressionRLEDecodeBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want []byte
+	}{
+		{
+			name: "test 1",
+			data: []byte{12, 'W', 1, 'B', 12, 'W', 3, 'B'},
+			want: []byte("WWWWWWWWWWWWBWWWWWWWWWWWWBBB"),
+		},
+		{
+			name: "test 2",
+			data: []byte{2, 'A', 1, 'B', 3, 'C', 1, 'D', 4, 'E'},
+			want: []byte("AABCCCDEEEE"),
+		},
+		{
+			name: "test 3",
+			data: []byte{4, 'A', 3, 'B', 2, 'C', 1, 'D', 1, 'A'},
+			want: []byte("AAAABBBCCDA"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compression.RLEdecodebytes(tt.data); !bytes.Equal(got, tt.want) {
+				t.Errorf("RLEdecodebytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+/* --- BENCHMARKS --- */
+func BenchmarkRLEncode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = compression.RLEncode("WWWWWWWWWWWWBWWWWWWWWWWWWBBB")
+	}
+}
+
+func BenchmarkRLEDecode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = compression.RLEdecode("12W1B12W3B")
+	}
+}
+
+func BenchmarkRLEncodeBytes(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = compression.RLEncodebytes([]byte("WWWWWWWWWWWWBWWWWWWWWWWWWBBB"))
+	}
+}
+
+func BenchmarkRLEDecodeBytes(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = compression.RLEdecodebytes([]byte{12, 'W', 1, 'B', 12, 'W', 3, 'B'})
+	}
+}


### PR DESCRIPTION
39 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.